### PR TITLE
Fix RebuildDb Script To Handle No Existing DB

### DIFF
--- a/backend/BIGGYM/ddl/01_createDB.ddl
+++ b/backend/BIGGYM/ddl/01_createDB.ddl
@@ -1,2 +1,2 @@
-drop database BIGGYM;
+drop database if exists BIGGYM;
 create database if not exists BIGGYM character set utf8 collate utf8_bin;


### PR DESCRIPTION
Current implementation of the script assumes that an instance of the DB exists and tries to drop it before creating it. This fix puts an if condition on the drop statement, to handle instances where the DB is setup for the first time.

Fix by @captainkirk854 